### PR TITLE
Control should now send action on click

### DIFF
--- a/Sample/Sample/ANSegmentedControl/ANSegmentedControl.m
+++ b/Sample/Sample/ANSegmentedControl/ANSegmentedControl.m
@@ -343,6 +343,7 @@
                     
                     [self setSelectedSegment:newSegment];
                     [[self window] invalidateCursorRectsForView:self];
+                    [self sendAction:[self action] to:[self target]];
                     
                     break;
                 default:


### PR DESCRIPTION
Should fix issue #5 where actions specified in IB were not triggered when the control was clicked by the user.
